### PR TITLE
Integrated traffic lights

### DIFF
--- a/app/src/templates/App.svelte
+++ b/app/src/templates/App.svelte
@@ -17,7 +17,7 @@
 	window.preferenceManager = new PreferenceManager(configDb);
 	Promise.all([
 		invoke('init_dictionary'),
-		window.preferenceManager.init()
+		window.preferenceManager.init(),
 	]).then(() => {
 		document.dispatchEvent(new Event('init'));
 		initializeStyles();
@@ -38,6 +38,7 @@
 	window.onload = () => {
 		elasticScroll({ appleDeviceOnly: false, intensity: 1 });
 	};
+	window.__TAURI__.os.platform().then(platform => window.platform = platform);
 	
 	const routes = {
 		'/': Search,

--- a/app/src/templates/components/Navigation/Navigation.svelte
+++ b/app/src/templates/components/Navigation/Navigation.svelte
@@ -1,5 +1,6 @@
 <script>
 import active from 'svelte-spa-router/active';
+import { handleError } from '../../utils/';
 import { 
 	SearchIcon,
 	BookOpenIcon,
@@ -66,13 +67,21 @@ const secondaryNavigation = [
 	}
 ];
 
+let isMacos = false;
 let enableBetaFeatures = false;
 let enableTransparency = false;
-let trafficLightMargin = window.__TAURI__.os.platform === 'darwin';
+let trafficLightMargin = false;
 
-window.preferenceManager.waitForInit().then(() => {
+Promise.all([
+	window.preferenceManager.waitForInit(),
+	window.__TAURI__.os.platform()
+]).then(responses => {
+	isMacos = responses[1] === 'darwin';
+	trafficLightMargin = isMacos;
 	enableBetaFeatures = window.preferenceManager.get('beta');
-	enableTransparency = window.__TAURI__.os.platform === 'darwin' && window.preferenceManager.get('transparency');
+	enableTransparency = isMacos && window.preferenceManager.get('transparency');
+}).catch(err => {
+	handleError('There was an unexpected error reading system information. Syng may not operate as expected. Please restart Syng. If this problem persists, please report this bug. For more details check the logs.', err);
 });
 
 // TODO: Don't let this get merged in.
@@ -108,10 +117,10 @@ ipcRenderer.on('leave-full-screen', () => {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-    margin-top: var(--sy-space);
+    	margin-top: var(--sy-space);
 }
 .navigation--primary-nav--macos {
-	margin-top: calc(35px + var(--sy-space));
+	margin-top: calc(35px + var(--sy-space--large));
 }
 .navigation--secondary-nav {
 	display: flex;

--- a/app/src/templates/components/SyTextInput/SyTextInput.svelte
+++ b/app/src/templates/components/SyTextInput/SyTextInput.svelte
@@ -49,8 +49,8 @@ const handleKeyup = event => {
 <style>
 .sy-text-input {
 	border: none;
-	padding: var(--sy-space--large) var(--sy-space);
-	margin: var(--sy-space--small);
+	padding: 0px;
+	margin: calc(var(--sy-space--small) + var(--sy-space--large)) calc(var(--sy-space--small) + var(--sy-space));
 	background-color: var(--sy-color--white);
 	color: var(--sy-color--black);
 }

--- a/app/src/templates/routes/Search.svelte
+++ b/app/src/templates/routes/Search.svelte
@@ -16,10 +16,21 @@ let fullResults = [];
 let activeWord;
 let searchLang = 'EN';
 let highlightActive = true;
+let isMacos = false;
+let enableTransparency = false;
+
+// Manually call the tauri platform promise instead of using `window.platform`
+// so that we can watch for updates and respond accordingly because this page
+// may load prior to `window.platform` being set.
+window.__TAURI__.os.platform().then(platform => {
+	isMacos = platform === 'darwin';
+
+	// Disabling transparency for now since it doesn't work in Tauri as well as in Electron
+	// enableTransparency = isMacos && window.preferenceManager.get('transparency');
+});
+
 const invoke = window.__TAURI__.invoke;
 const langSwitcher = ['EN', 'PY', 'ZH'];
-const enableDrag = window.__TAURI__.os.platform === 'darwin';
-const enableTransparency = window.__TAURI__.os.platform === 'darwin' && window.preferenceManager.get('transparency');
 const updateSearchResults = (results, clearable) => {
 	if(results.length || clearable) {
 		highlightActive = false;
@@ -138,9 +149,6 @@ const handleLink = event => {
 .search-bar-container--transparency {
 	background-color: var(--sy-color--white--transparency);
 }
-.search-bar-container--macos {
-	-webkit-app-region: drag;
-}
 .search-content-container {
 	display: flex;
 }
@@ -166,7 +174,7 @@ const handleLink = event => {
 </style>
 
 <div class="search-page-container">
-	<div class="search-bar-container" class:search-bar-container--macos={enableDrag} class:search-bar-container--transparency={enableTransparency} data-testid="search-bar-container">
+	<div class="search-bar-container" class:search-bar-container--transparency={enableTransparency} data-testid="search-bar-container" data-tauri-drag-region={isMacos ? true : undefined}>
 		<SyButton style="ghost" size="large" disabled={ (searchHistory[historyPosition - 1] == undefined) } on:click="{historyBack}">
 			<ChevronLeftIcon size="20" />
 		</SyButton>
@@ -176,7 +184,7 @@ const handleLink = event => {
 		<SyButton style="ghost" size="large" on:click={ () => switchLang() }>
 			{ searchLang }
 		</SyButton>
-		<SyTextInput style="ghost" size="large" placeholder="Search..." id="search" transparency={enableTransparency} on:change={ e => query(e.detail, true) } on:keyup={ e => query(e.detail, false) } on:enter={ handleEnter }/>
+		<SyTextInput style="ghost" size="large" placeholder="Search..." id="search" transparency={enableTransparency} on:change={ e => query(e.detail, true) } on:keyup={ e => query(e.detail, false) } on:enter={ handleEnter } />
 	</div>
 	<div class="search-content-container">
 		<div class="search-results" data-elastic>

--- a/app/src/templates/routes/Settings.svelte
+++ b/app/src/templates/routes/Settings.svelte
@@ -1,7 +1,7 @@
 <script>
 import SyToggle from '../components/SyToggle/SyToggle.svelte';
 import ToneColorPicker from '../components/SettingsOption/ToneColorPicker.svelte';
-const isMacos = window.__TAURI__.os.platform === 'darwin';
+const isMacos = window.platform === 'darwin';
 
 let preferences = [
 	{
@@ -22,8 +22,9 @@ let preferences = [
 	}
 ];
 
-// Load system specific preferences
-if (isMacos) {
+/* Disabling transparency for the time being since Tauri handles it a bit differently than Electron */
+/*
+if(isMacos) {
 	const macOSPreferences = [
 		{
 			label: 'Transparency',
@@ -38,6 +39,7 @@ if (isMacos) {
 
 	preferences = [...macOSPreferences, ...preferences];
 }
+*/
 </script>
 
 <style>
@@ -50,9 +52,6 @@ if (isMacos) {
 .settings--title {
 	padding: var(--sy-space--extra-large) var(--sy-space);
 }
-.settings--title--macos {
-	-webkit-app-region: drag;
-}
 .settings--setting {
 	display: grid;
 	grid-template-columns: 1fr 1fr;
@@ -64,8 +63,8 @@ if (isMacos) {
 </style>
 
 <div class="settings--container">
-	<div class="settings--title" class:settings--title--macos={isMacos}>
-		<h1>Settings</h1>
+	<div class="settings--title" data-tauri-drag-region={isMacos ? true : undefined}>
+		<h1 data-tauri-drag-region={isMacos ? true : undefined}>Settings</h1>
 	</div>
 	<div class="settings--content">
 		{#each preferences as preference}

--- a/app/src/templates/utils/preferenceManager.js
+++ b/app/src/templates/utils/preferenceManager.js
@@ -60,7 +60,7 @@ export class PreferenceManager {
 				if(err.name === 'not_found') {
 					return {
 						_id: 'config',
-						transparency: createPreference(true, true),
+						transparency: createPreference(true, false),
 						beta: createPreference(true, false),
 						toneColors: createPreference(true, {
 							colors: ['--sy-color--blue-3', 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2678,6 +2678,7 @@ name = "syng"
 version = "2.0.0"
 dependencies = [
  "chinese_dictionary",
+ "cocoa",
  "serde",
  "serde_json",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,6 +17,7 @@ chinese_dictionary = "2.1.1"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.0.5", features = ["api-all"] }
+cocoa = "0.24.0"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,7 +7,7 @@ extern crate chinese_dictionary;
 use chinese_dictionary as cd;
 use serde::Serialize;
 use std::sync::Once;
-use tauri::Manager;
+use tauri::{Manager, Runtime, Window};
 
 static INIT: Once = Once::new();
 
@@ -110,10 +110,58 @@ fn query_by_english(text: String) -> Vec<WordEntry> {
         .collect()
 }
 
+pub enum ToolbarThickness {
+    Thick,
+    Medium,
+    Thin,
+}
+
+pub trait WindowExt {
+    #[cfg(target_os = "macos")]
+    fn set_transparent_titlebar(&self, thickness: ToolbarThickness);
+}
+
+impl<R: Runtime> WindowExt for Window<R> {
+    #[cfg(target_os = "macos")]
+    fn set_transparent_titlebar(&self, thickness: ToolbarThickness) {
+        use cocoa::appkit::{NSWindow, NSWindowTitleVisibility};
+
+        unsafe {
+            let id = self.ns_window().unwrap() as cocoa::base::id;
+
+            id.setTitlebarAppearsTransparent_(cocoa::base::YES);
+
+            match thickness {
+                ToolbarThickness::Thick => {
+                    self.set_title("").expect("Title wasn't set to ''");
+                    make_toolbar(id);
+                }
+                ToolbarThickness::Medium => {
+                    id.setTitleVisibility_(NSWindowTitleVisibility::NSWindowTitleHidden);
+                    make_toolbar(id);
+                }
+                ToolbarThickness::Thin => {
+                    id.setTitleVisibility_(NSWindowTitleVisibility::NSWindowTitleHidden);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn make_toolbar(id: cocoa::base::id) {
+    use cocoa::appkit::{NSToolbar, NSWindow};
+
+    let new_toolbar = NSToolbar::alloc(id);
+    new_toolbar.init_();
+    id.setToolbar_(new_toolbar);
+}
+
 fn main() {
     tauri::Builder::default()
         .setup(|app| {
             let window = app.get_window("main").unwrap();
+            window.set_transparent_titlebar(ToolbarThickness::Thick);
             window.open_devtools();
             Ok(())
         })


### PR DESCRIPTION
#### Known Issues
- Some click events aren't captured by the interactive elements on the search bar on the search page on macOS. This is due to how the integrated traffic lights are implemented. Traffic light customization in Tauri isn't as robust as in Electron. The current solution is to have a thick transparent titlebar, and this titlebar ends up consuming some of the click events that are intented for the interactive elements along the search bar. This solution is a bit of a workaround / hack. Resolving this issue will be revisited closer to the full release of v2, hopefully Tauri gets Electron-like support for this before then. 
- On macOS, in fullscreen mode the search bar on the search page is completely inaccessible. This is due to how traffic light integration has been implemented, other caviets related to this are outlined above in the section regarding click events on the search bar. This issue will be resolved when that issue is resolved. Resolving that issue will be revisited closer to the full release of v2, hopefully Tauri gets Electron-like support for traffic light integration before then.